### PR TITLE
[#12] `method` should have type `string` not `"string"`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,8 +7,8 @@
 
 This impacts:
 
-- [`srcResDecorator`](https://github.com/asos-craigmorten/opine-http-proxy/tree/main#srcresdecoratorreq-res-proxyres-proxyresdata-supports-promise)
-- [`filterRes`](https://github.com/asos-craigmorten/opine-http-proxy/tree/main#filterresproxyres-proxyresdata-supports-promise-form)
+- [`srcResDecorator`](https://github.com/cmorten/opine-http-proxy/tree/main#srcresdecoratorreq-res-proxyres-proxyresdata-supports-promise)
+- [`filterRes`](https://github.com/cmorten/opine-http-proxy/tree/main#filterresproxyres-proxyresdata-supports-promise-form)
 
 Where the `proxyResData` argument will be of type `Uint8Array|null` and not
 `string|null`. If you require the value to be a string, you will need to decode

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ChangeLog
 
+## [3.0.1] - 10-01-2022
+
+- [#12] `method` should have type `string` not `"string"`
+- feat: update to Deno `1.17.2`, std `0.120.0`
+- feat: upgrade Opine to `2.0.2` in tests
+- feat: other minor dependency upgrades
+- chore: changes to reflect GitHub repo transfer
+
 ## [3.0.0] - 21-11-2021
 
 - [#10] Store and pass the proxy response data as an `Uint8Array` instead of

--- a/.github/CODEOWNERS.md
+++ b/.github/CODEOWNERS.md
@@ -1,2 +1,1 @@
-* @asos-craigmorten
 * @cmorten

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Deno
         uses: denolib/setup-deno@v2
         with:
-          deno-version: 1.16.2
+          deno-version: 1.17.2
       - run: make typedoc
       - run: make ci
       - name: Publish Updated Type Docs

--- a/.github/workflows/publish-egg.yml
+++ b/.github/workflows/publish-egg.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: denolib/setup-deno@v2
         with:
-          deno-version: 1.16.2
+          deno-version: 1.17.2
       - run: deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.3.10/eggs.ts
       - run: |
           export PATH="/home/runner/.deno/bin:$PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        deno-version: [1.16.2]
+        deno-version: [1.17.2]
 
     runs-on: ${{ matrix.os }}
 
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        deno-version: [1.16.2]
+        deno-version: [1.17.2]
 
     runs-on: ${{ matrix.os }}
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-<craig.morten@asos.com>. All complaints will be reviewed and investigated promptly
+<craig.morten@hotmail.co.uk>. All complaints will be reviewed and investigated promptly
 and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 (The MIT License)
 
-Copyright (c) 2020 Craig Morten <craig.morten@asos.com>
+Copyright (c) 2020 Craig Morten <craig.morten@hotmail.co.uk>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -2,31 +2,31 @@
 
 Proxy middleware for Deno Opine HTTP servers.
 
-[![GitHub tag](https://img.shields.io/github/tag/asos-craigmorten/opine-http-proxy)](https://github.com/asos-craigmorten/opine-http-proxy/tags/)
-![Test](https://github.com/asos-craigmorten/opine-http-proxy/workflows/Test/badge.svg)
+[![GitHub tag](https://img.shields.io/github/tag/cmorten/opine-http-proxy)](https://github.com/cmorten/opine-http-proxy/tags/)
+![Test](https://github.com/cmorten/opine-http-proxy/workflows/Test/badge.svg)
 [![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/opineHttpProxy/mod.ts)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
-[![GitHub issues](https://img.shields.io/github/issues/asos-craigmorten/opine-http-proxy)](https://img.shields.io/github/issues/asos-craigmorten/opine-http-proxy)
-![GitHub stars](https://img.shields.io/github/stars/asos-craigmorten/opine-http-proxy)
-![GitHub forks](https://img.shields.io/github/forks/asos-craigmorten/opine-http-proxy)
-![opine-http-proxy License](https://img.shields.io/github/license/asos-craigmorten/opine-http-proxy)
-[![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/asos-craigmorten/opine-http-proxy/graphs/commit-activity)
+[![GitHub issues](https://img.shields.io/github/issues/cmorten/opine-http-proxy)](https://img.shields.io/github/issues/cmorten/opine-http-proxy)
+![GitHub stars](https://img.shields.io/github/stars/cmorten/opine-http-proxy)
+![GitHub forks](https://img.shields.io/github/forks/cmorten/opine-http-proxy)
+![opine-http-proxy License](https://img.shields.io/github/license/cmorten/opine-http-proxy)
+[![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/cmorten/opine-http-proxy/graphs/commit-activity)
 
 <p align="left">
    <a href="https://deno.land/x/opineHttpProxy"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Flatest-version%2Fx%2FopineHttpProxy%2Fmod.ts" alt="opine-http-proxy latest /x/ version" /></a>
-   <a href="https://github.com/denoland/deno/blob/main/Releases.md"><img src="https://img.shields.io/badge/deno-^1.16.2-brightgreen?logo=deno" alt="Minimum supported Deno version" /></a>
+   <a href="https://github.com/denoland/deno/blob/main/Releases.md"><img src="https://img.shields.io/badge/deno-^1.17.2-brightgreen?logo=deno" alt="Minimum supported Deno version" /></a>
    <a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/opineHttpProxy/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fdep-count%2Fx%2FopineHttpProxy%2Fmod.ts" alt="opine-http-proxy dependency count" /></a>
    <a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/opineHttpProxy/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fupdates%2Fx%2FopineHttpProxy%2Fmod.ts" alt="opine-http-proxy dependency outdatedness" /></a>
    <a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/opineHttpProxy/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fcache-size%2Fx%2FopineHttpProxy%2Fmod.ts" alt="opine-http-proxy cached size" /></a>
 </p>
 
 ```ts
-import { proxy } from "https://deno.land/x/opineHttpProxy@3.0.0/mod.ts";
-import { opine } from "https://deno.land/x/opine@1.9.1/mod.ts";
+import { proxy } from "https://deno.land/x/opineHttpProxy@4.0.0/mod.ts";
+import { opine } from "https://deno.land/x/opine@2.0.2/mod.ts";
 
 const app = opine();
 
-app.use(proxy("https://github.com/asos-craigmorten/opine-http-proxy"));
+app.use(proxy("https://github.com/cmorten/opine-http-proxy"));
 
 app.listen(3000);
 ```
@@ -41,15 +41,15 @@ Before importing, [download and install Deno](https://deno.land/#installation).
 You can then import opine-http-proxy straight into your project:
 
 ```ts
-import { proxy } from "https://deno.land/x/opineHttpProxy@3.0.0/mod.ts";
+import { proxy } from "https://deno.land/x/opineHttpProxy@4.0.0/mod.ts";
 ```
 
 ## Docs
 
-- [opine-http-proxy Type Docs](https://asos-craigmorten.github.io/opine-http-proxy/)
+- [opine-http-proxy Type Docs](https://cmorten.github.io/opine-http-proxy/)
 - [opine-http-proxy Deno Docs](https://doc.deno.land/https/deno.land/x/opineHttpProxy/mod.ts)
-- [License](https://github.com/asos-craigmorten/opine-http-proxy/blob/main/LICENSE.md)
-- [Changelog](https://github.com/asos-craigmorten/opine-http-proxy/blob/main/.github/CHANGELOG.md)
+- [License](https://github.com/cmorten/opine-http-proxy/blob/main/LICENSE.md)
+- [Changelog](https://github.com/cmorten/opine-http-proxy/blob/main/.github/CHANGELOG.md)
 
 ## Usage
 
@@ -432,7 +432,7 @@ app.use(
 
 ## Contributing
 
-[Contributing guide](https://github.com/asos-craigmorten/opine-http-proxy/blob/main/.github/CONTRIBUTING.md)
+[Contributing guide](https://github.com/cmorten/opine-http-proxy/blob/main/.github/CONTRIBUTING.md)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Proxy middleware for Deno Opine HTTP servers.
 </p>
 
 ```ts
-import { proxy } from "https://deno.land/x/opineHttpProxy@4.0.0/mod.ts";
+import { proxy } from "https://deno.land/x/opineHttpProxy@3.0.1/mod.ts";
 import { opine } from "https://deno.land/x/opine@2.0.2/mod.ts";
 
 const app = opine();
@@ -41,7 +41,7 @@ Before importing, [download and install Deno](https://deno.land/#installation).
 You can then import opine-http-proxy straight into your project:
 
 ```ts
-import { proxy } from "https://deno.land/x/opineHttpProxy@4.0.0/mod.ts";
+import { proxy } from "https://deno.land/x/opineHttpProxy@3.0.1/mod.ts";
 ```
 
 ## Docs

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,3 @@
-export { join } from "https://deno.land/std@0.115.1/path/mod.ts";
-export { read } from "https://deno.land/x/opine@1.9.1/src/middleware/bodyParser/read.ts";
-export { parseUrl } from "https://deno.land/x/opine@1.9.1/src/utils/parseUrl.ts";
+export { join } from "https://deno.land/std@0.120.0/path/mod.ts";
+export { read } from "https://deno.land/x/opine@2.0.2/src/middleware/bodyParser/read.ts";
+export { parseUrl } from "https://deno.land/x/opine@2.0.2/src/utils/parseUrl.ts";

--- a/docs/classes/_steps_sendproxyreq_.timeouterror.html
+++ b/docs/classes/_steps_sendproxyreq_.timeouterror.html
@@ -127,7 +127,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L11">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L11">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:11</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">code<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;ECONTIMEDOUT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L5">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L5">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -163,7 +163,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides Error.message</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L13">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L13">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -174,7 +174,7 @@
 					<aside class="tsd-sources">
 						<p>Overrides Error.name</p>
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L6">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L6">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -184,7 +184,7 @@
 					<div class="tsd-signature tsd-kind-icon">ok<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L7">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L7">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -194,7 +194,7 @@
 					<div class="tsd-signature tsd-kind-icon">redirected<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> = false</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L8">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L8">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -215,7 +215,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 408</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L9">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L9">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -225,7 +225,7 @@
 					<div class="tsd-signature tsd-kind-icon">status<wbr>Text<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;ECONTIMEDOUT&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L10">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L10">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -235,7 +235,7 @@
 					<div class="tsd-signature tsd-kind-icon">type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> = &quot;error&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L11">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:11</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L11">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:11</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -245,7 +245,7 @@
 					<div class="tsd-signature tsd-kind-icon">url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L13">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L13">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -272,7 +272,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L17">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L17">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">any</span></h4>

--- a/docs/index.html
+++ b/docs/index.html
@@ -82,7 +82,7 @@
 					<a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/opineHttpProxy/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fupdates%2Fx%2FopineHttpProxy%2Fmod.ts" alt="opine-http-proxy dependency outdatedness" /></a>
 					<a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/opineHttpProxy/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fcache-size%2Fx%2FopineHttpProxy%2Fmod.ts" alt="opine-http-proxy cached size" /></a>
 				</p>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { proxy } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opineHttpProxy@4.0.0/mod.ts&quot;</span>;
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { proxy } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opineHttpProxy@3.0.1/mod.ts&quot;</span>;
 <span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@2.0.2/mod.ts&quot;</span>;
 
 <span class="hljs-keyword">const</span> app = opine();
@@ -98,7 +98,7 @@ app.listen(<span class="hljs-number">3000</span>);
 				repo and via the <a href="https://deno.land/x">Deno Registry</a>.</p>
 				<p>Before importing, <a href="https://deno.land/#installation">download and install Deno</a>.</p>
 				<p>You can then import opine-http-proxy straight into your project:</p>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { proxy } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opineHttpProxy@4.0.0/mod.ts&quot;</span>;
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { proxy } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opineHttpProxy@3.0.1/mod.ts&quot;</span>;
 </code></pre>
 				<a href="#docs" id="docs" style="color: inherit; text-decoration: none;">
 					<h2>Docs</h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,28 +66,28 @@
 					<h1>opine-http-proxy</h1>
 				</a>
 				<p>Proxy middleware for Deno Opine HTTP servers.</p>
-				<p><a href="https://github.com/asos-craigmorten/opine-http-proxy/tags/"><img src="https://img.shields.io/github/tag/asos-craigmorten/opine-http-proxy" alt="GitHub tag"></a>
-					<img src="https://github.com/asos-craigmorten/opine-http-proxy/workflows/Test/badge.svg" alt="Test">
+				<p><a href="https://github.com/cmorten/opine-http-proxy/tags/"><img src="https://img.shields.io/github/tag/cmorten/opine-http-proxy" alt="GitHub tag"></a>
+					<img src="https://github.com/cmorten/opine-http-proxy/workflows/Test/badge.svg" alt="Test">
 					<a href="https://doc.deno.land/https/deno.land/x/opineHttpProxy/mod.ts"><img src="https://doc.deno.land/badge.svg" alt="deno doc"></a>
 					<a href="http://makeapullrequest.com"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
-					<a href="https://img.shields.io/github/issues/asos-craigmorten/opine-http-proxy"><img src="https://img.shields.io/github/issues/asos-craigmorten/opine-http-proxy" alt="GitHub issues"></a>
-					<img src="https://img.shields.io/github/stars/asos-craigmorten/opine-http-proxy" alt="GitHub stars">
-					<img src="https://img.shields.io/github/forks/asos-craigmorten/opine-http-proxy" alt="GitHub forks">
-					<img src="https://img.shields.io/github/license/asos-craigmorten/opine-http-proxy" alt="opine-http-proxy License">
-				<a href="https://GitHub.com/asos-craigmorten/opine-http-proxy/graphs/commit-activity"><img src="https://img.shields.io/badge/Maintained%3F-yes-green.svg" alt="Maintenance"></a></p>
+					<a href="https://img.shields.io/github/issues/cmorten/opine-http-proxy"><img src="https://img.shields.io/github/issues/cmorten/opine-http-proxy" alt="GitHub issues"></a>
+					<img src="https://img.shields.io/github/stars/cmorten/opine-http-proxy" alt="GitHub stars">
+					<img src="https://img.shields.io/github/forks/cmorten/opine-http-proxy" alt="GitHub forks">
+					<img src="https://img.shields.io/github/license/cmorten/opine-http-proxy" alt="opine-http-proxy License">
+				<a href="https://GitHub.com/cmorten/opine-http-proxy/graphs/commit-activity"><img src="https://img.shields.io/badge/Maintained%3F-yes-green.svg" alt="Maintenance"></a></p>
 				<p align="left">
 					<a href="https://deno.land/x/opineHttpProxy"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Flatest-version%2Fx%2FopineHttpProxy%2Fmod.ts" alt="opine-http-proxy latest /x/ version" /></a>
-					<a href="https://github.com/denoland/deno/blob/main/Releases.md"><img src="https://img.shields.io/badge/deno-^1.16.2-brightgreen?logo=deno" alt="Minimum supported Deno version" /></a>
+					<a href="https://github.com/denoland/deno/blob/main/Releases.md"><img src="https://img.shields.io/badge/deno-^1.17.2-brightgreen?logo=deno" alt="Minimum supported Deno version" /></a>
 					<a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/opineHttpProxy/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fdep-count%2Fx%2FopineHttpProxy%2Fmod.ts" alt="opine-http-proxy dependency count" /></a>
 					<a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/opineHttpProxy/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fupdates%2Fx%2FopineHttpProxy%2Fmod.ts" alt="opine-http-proxy dependency outdatedness" /></a>
 					<a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/opineHttpProxy/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fcache-size%2Fx%2FopineHttpProxy%2Fmod.ts" alt="opine-http-proxy cached size" /></a>
 				</p>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { proxy } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opineHttpProxy@3.0.0/mod.ts&quot;</span>;
-<span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@1.9.1/mod.ts&quot;</span>;
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { proxy } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opineHttpProxy@4.0.0/mod.ts&quot;</span>;
+<span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@2.0.2/mod.ts&quot;</span>;
 
 <span class="hljs-keyword">const</span> app = opine();
 
-app.use(proxy(<span class="hljs-string">&quot;https://github.com/asos-craigmorten/opine-http-proxy&quot;</span>));
+app.use(proxy(<span class="hljs-string">&quot;https://github.com/cmorten/opine-http-proxy&quot;</span>));
 
 app.listen(<span class="hljs-number">3000</span>);
 </code></pre>
@@ -98,16 +98,16 @@ app.listen(<span class="hljs-number">3000</span>);
 				repo and via the <a href="https://deno.land/x">Deno Registry</a>.</p>
 				<p>Before importing, <a href="https://deno.land/#installation">download and install Deno</a>.</p>
 				<p>You can then import opine-http-proxy straight into your project:</p>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { proxy } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opineHttpProxy@3.0.0/mod.ts&quot;</span>;
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { proxy } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opineHttpProxy@4.0.0/mod.ts&quot;</span>;
 </code></pre>
 				<a href="#docs" id="docs" style="color: inherit; text-decoration: none;">
 					<h2>Docs</h2>
 				</a>
 				<ul>
-					<li><a href="https://asos-craigmorten.github.io/opine-http-proxy/">opine-http-proxy Type Docs</a></li>
+					<li><a href="https://cmorten.github.io/opine-http-proxy/">opine-http-proxy Type Docs</a></li>
 					<li><a href="https://doc.deno.land/https/deno.land/x/opineHttpProxy/mod.ts">opine-http-proxy Deno Docs</a></li>
-					<li><a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/main/LICENSE.md">License</a></li>
-					<li><a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/main/.github/CHANGELOG.md">Changelog</a></li>
+					<li><a href="https://github.com/cmorten/opine-http-proxy/blob/main/LICENSE.md">License</a></li>
+					<li><a href="https://github.com/cmorten/opine-http-proxy/blob/main/.github/CHANGELOG.md">Changelog</a></li>
 				</ul>
 				<a href="#usage" id="usage" style="color: inherit; text-decoration: none;">
 					<h2>Usage</h2>
@@ -435,7 +435,7 @@ app.use(
 				<a href="#contributing" id="contributing" style="color: inherit; text-decoration: none;">
 					<h2>Contributing</h2>
 				</a>
-				<p><a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/main/.github/CONTRIBUTING.md">Contributing guide</a></p>
+				<p><a href="https://github.com/cmorten/opine-http-proxy/blob/main/.github/CONTRIBUTING.md">Contributing guide</a></p>
 				<hr>
 				<a href="#license" id="license" style="color: inherit; text-decoration: none;">
 					<h2>License</h2>

--- a/docs/interfaces/_createstate_.proxy.html
+++ b/docs/interfaces/_createstate_.proxy.html
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">req<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Request</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L24">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L24">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">req<wbr>Init<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RequestInit</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L27">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L27">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">res<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Response</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L25">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L25">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">res<wbr>Data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L26">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L26">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">URL</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L28">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L28">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_createstate_.proxyparams.html
+++ b/docs/interfaces/_createstate_.proxyparams.html
@@ -111,7 +111,7 @@
 					<div class="tsd-signature tsd-kind-icon">options<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Opts</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L14">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L14">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -121,7 +121,7 @@
 					<div class="tsd-signature tsd-kind-icon">url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">ProxyUrl</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L13">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:13</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L13">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:13</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_createstate_.proxystate.html
+++ b/docs/interfaces/_createstate_.proxystate.html
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">options<span class="tsd-signature-symbol">:</span> <a href="_resolveoptions_.proxyoptions.html" class="tsd-signature-type">ProxyOptions</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L40">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:40</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L40">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:40</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">params<span class="tsd-signature-symbol">:</span> <a href="_createstate_.proxyparams.html" class="tsd-signature-type">ProxyParams</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Req</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">ProxyUrl</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">Opts</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L41">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:41</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L41">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:41</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -139,7 +139,7 @@
 					<div class="tsd-signature tsd-kind-icon">proxy<span class="tsd-signature-symbol">:</span> <a href="_createstate_.proxy.html" class="tsd-signature-type">Proxy</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L39">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:39</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L39">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:39</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -149,7 +149,7 @@
 					<div class="tsd-signature tsd-kind-icon">src<span class="tsd-signature-symbol">:</span> <a href="_createstate_.source.html" class="tsd-signature-type">Source</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Req</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">Res</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">Next</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L38">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:38</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L38">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:38</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_createstate_.proxyurlfunction.html
+++ b/docs/interfaces/_createstate_.proxyurlfunction.html
@@ -92,7 +92,7 @@
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L4">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:4</a></li>
+								<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L4">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:4</a></li>
 							</ul>
 						</aside>
 						<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/_createstate_.source.html
+++ b/docs/interfaces/_createstate_.source.html
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">next<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Next</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L20">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L20">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 					<div class="tsd-signature tsd-kind-icon">req<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Req</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L18">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L18">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -132,7 +132,7 @@
 					<div class="tsd-signature tsd-kind-icon">res<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Res</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L19">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L19">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/_resolveoptions_.proxyoptions.html
+++ b/docs/interfaces/_resolveoptions_.proxyoptions.html
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">filter<wbr>Req<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, res<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L22">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:22</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L22">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:22</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">filter<wbr>Res<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>proxyRes<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Response</span>, proxyResData<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L91">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:91</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L91">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:91</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -209,7 +209,7 @@
 					<div class="tsd-signature tsd-kind-icon">memoize<wbr>Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L137">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:137</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L137">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:137</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -228,7 +228,7 @@
 					<div class="tsd-signature tsd-kind-icon">memoized<wbr>Url<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">URL</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L145">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:145</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L145">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:145</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -244,7 +244,7 @@
 					<div class="tsd-signature tsd-kind-icon">method<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"string"</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L170">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:170</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L170">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:170</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -260,7 +260,7 @@
 					<div class="tsd-signature tsd-kind-icon">parse<wbr>Req<wbr>Body<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L109">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:109</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L109">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:109</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -277,7 +277,7 @@
 					<div class="tsd-signature tsd-kind-icon">preserve<wbr>Host<wbr>Header<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L99">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:99</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L99">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:99</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -293,7 +293,7 @@
 					<div class="tsd-signature tsd-kind-icon">proxy<wbr>Error<wbr>Handler<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>err<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, res<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, next<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L32">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L32">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:32</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -335,7 +335,7 @@
 					<div class="tsd-signature tsd-kind-icon">proxy<wbr>Req<wbr>Init<wbr>Decorator<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>proxyReqOpts<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">RequestInit</span>, srcReq<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">RequestInit</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">RequestInit</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L52">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:52</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L52">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:52</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -376,7 +376,7 @@
 					<div class="tsd-signature tsd-kind-icon">proxy<wbr>Req<wbr>Url<wbr>Decorator<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>url<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">URL</span>, req<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">URL</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">URL</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L43">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:43</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L43">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:43</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -415,7 +415,7 @@
 					<div class="tsd-signature tsd-kind-icon">req<wbr>AsBuffer<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L124">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:124</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L124">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:124</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -431,7 +431,7 @@
 					<div class="tsd-signature tsd-kind-icon">req<wbr>Body<wbr>Encoding<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">"utf-8"</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L116">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:116</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L116">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:116</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -446,7 +446,7 @@
 					<div class="tsd-signature tsd-kind-icon">secure<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L154">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:154</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L154">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:154</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -463,7 +463,7 @@
 					<div class="tsd-signature tsd-kind-icon">src<wbr>Res<wbr>Decorator<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>srcReq<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, srcRes<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, proxyRes<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Response</span>, proxyResData<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">any</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L75">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:75</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L75">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:75</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -508,7 +508,7 @@
 					<div class="tsd-signature tsd-kind-icon">src<wbr>Res<wbr>Header<wbr>Decorator<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>headers<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Headers</span>, srcReq<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, srcRes<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span>, proxyReq<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Request</span>, proxyRes<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Response</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Headers</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L62">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:62</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L62">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:62</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -556,7 +556,7 @@
 					<div class="tsd-signature tsd-kind-icon">timeout<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L162">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:162</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L162">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:162</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/modules/_createstate_.html
+++ b/docs/modules/_createstate_.html
@@ -99,7 +99,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/createState.ts#L44">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:44</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/createState.ts#L44">home/runner/work/opine-http-proxy/opine-http-proxy/src/createState.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>

--- a/docs/modules/_isunset_.html
+++ b/docs/modules/_isunset_.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/isUnset.ts#L1">home/runner/work/opine-http-proxy/opine-http-proxy/src/isUnset.ts:1</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/isUnset.ts#L1">home/runner/work/opine-http-proxy/opine-http-proxy/src/isUnset.ts:1</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_proxy_.html
+++ b/docs/modules/_proxy_.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/proxy.ts#L41">home/runner/work/opine-http-proxy/opine-http-proxy/src/proxy.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/proxy.ts#L41">home/runner/work/opine-http-proxy/opine-http-proxy/src/proxy.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_requestoptions_.html
+++ b/docs/modules/_requestoptions_.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">encoder<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">TextEncoder</span><span class="tsd-signature-symbol"> = new TextEncoder()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L125">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:125</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L125">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:125</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L127">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:127</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L127">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:127</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -139,7 +139,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L137">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:137</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L137">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:137</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -162,7 +162,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L102">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:102</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L102">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:102</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -191,7 +191,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L38">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L38">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -220,7 +220,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L60">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:60</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L60">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:60</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -246,7 +246,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L58">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:58</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L58">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:58</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -269,7 +269,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L6">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L6">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -292,7 +292,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L80">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:80</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L80">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:80</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -321,7 +321,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L88">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:88</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/requestOptions.ts#L88">home/runner/work/opine-http-proxy/opine-http-proxy/src/requestOptions.ts:88</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_resolveoptions_.html
+++ b/docs/modules/_resolveoptions_.html
@@ -96,7 +96,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L176">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:176</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L176">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:176</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -121,7 +121,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L183">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:183</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/resolveOptions.ts#L183">home/runner/work/opine-http-proxy/opine-http-proxy/src/resolveOptions.ts:183</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_steps_buildproxyreqinit_.html
+++ b/docs/modules/_steps_buildproxyreqinit_.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/buildProxyReqInit.ts#L4">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/buildProxyReqInit.ts:4</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/buildProxyReqInit.ts#L4">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/buildProxyReqInit.ts:4</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_steps_buildproxyurl_.html
+++ b/docs/modules/_steps_buildproxyurl_.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/buildProxyUrl.ts#L4">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/buildProxyUrl.ts:4</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/buildProxyUrl.ts#L4">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/buildProxyUrl.ts:4</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_steps_copyproxyresheaderstouserres_.html
+++ b/docs/modules/_steps_copyproxyresheaderstouserres_.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/copyProxyResHeadersToUserRes.ts#L3">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/copyProxyResHeadersToUserRes.ts:3</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/copyProxyResHeadersToUserRes.ts#L3">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/copyProxyResHeadersToUserRes.ts:3</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_steps_decorateproxyreqinit_.html
+++ b/docs/modules/_steps_decorateproxyreqinit_.html
@@ -90,7 +90,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/decorateProxyReqInit.ts#L5">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateProxyReqInit.ts:5</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/decorateProxyReqInit.ts#L5">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateProxyReqInit.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/decorateProxyReqInit.ts#L3">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateProxyReqInit.ts:3</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/decorateProxyReqInit.ts#L3">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateProxyReqInit.ts:3</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_steps_decorateproxyrequrl_.html
+++ b/docs/modules/_steps_decorateproxyrequrl_.html
@@ -90,7 +90,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/decorateProxyReqUrl.ts#L5">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateProxyReqUrl.ts:5</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/decorateProxyReqUrl.ts#L5">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateProxyReqUrl.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/decorateProxyReqUrl.ts#L3">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateProxyReqUrl.ts:3</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/decorateProxyReqUrl.ts#L3">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateProxyReqUrl.ts:3</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_steps_decoratesrcres_.html
+++ b/docs/modules/_steps_decoratesrcres_.html
@@ -90,7 +90,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/decorateSrcRes.ts#L12">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateSrcRes.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/decorateSrcRes.ts#L12">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateSrcRes.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/decorateSrcRes.ts#L5">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateSrcRes.ts:5</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/decorateSrcRes.ts#L5">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateSrcRes.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_steps_decoratesrcresheaders_.html
+++ b/docs/modules/_steps_decoratesrcresheaders_.html
@@ -90,7 +90,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/decorateSrcResHeaders.ts#L5">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateSrcResHeaders.ts:5</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/decorateSrcResHeaders.ts#L5">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateSrcResHeaders.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -113,7 +113,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/decorateSrcResHeaders.ts#L3">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateSrcResHeaders.ts:3</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/decorateSrcResHeaders.ts#L3">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/decorateSrcResHeaders.ts:3</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_steps_filterproxyres_.html
+++ b/docs/modules/_steps_filterproxyres_.html
@@ -90,7 +90,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/filterProxyRes.ts#L4">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/filterProxyRes.ts:4</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/filterProxyRes.ts#L4">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/filterProxyRes.ts:4</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/filterProxyRes.ts#L6">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/filterProxyRes.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/filterProxyRes.ts#L6">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/filterProxyRes.ts:6</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_steps_filtersrcreq_.html
+++ b/docs/modules/_steps_filtersrcreq_.html
@@ -90,7 +90,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/filterSrcReq.ts#L3">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/filterSrcReq.ts:3</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/filterSrcReq.ts#L3">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/filterSrcReq.ts:3</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
@@ -107,7 +107,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/filterSrcReq.ts#L5">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/filterSrcReq.ts:5</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/filterSrcReq.ts#L5">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/filterSrcReq.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_steps_handleproxyerrors_.html
+++ b/docs/modules/_steps_handleproxyerrors_.html
@@ -90,7 +90,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/handleProxyErrors.ts#L2">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/handleProxyErrors.ts:2</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/handleProxyErrors.ts#L2">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/handleProxyErrors.ts:2</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/handleProxyErrors.ts#L7">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/handleProxyErrors.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/handleProxyErrors.ts#L7">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/handleProxyErrors.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_steps_prepareproxyreq_.html
+++ b/docs/modules/_steps_prepareproxyreq_.html
@@ -92,7 +92,7 @@
 					<div class="tsd-signature tsd-kind-icon">encoder<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">TextEncoder</span><span class="tsd-signature-symbol"> = new TextEncoder()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/prepareProxyReq.ts#L5">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/prepareProxyReq.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/prepareProxyReq.ts#L5">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/prepareProxyReq.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/prepareProxyReq.ts#L7">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/prepareProxyReq.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/prepareProxyReq.ts#L7">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/prepareProxyReq.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -132,7 +132,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/prepareProxyReq.ts#L15">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/prepareProxyReq.ts:15</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/prepareProxyReq.ts#L15">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/prepareProxyReq.ts:15</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_steps_sendproxyreq_.html
+++ b/docs/modules/_steps_sendproxyreq_.html
@@ -95,7 +95,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L22">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/sendProxyReq.ts#L22">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendProxyReq.ts:22</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_steps_sendsrcres_.html
+++ b/docs/modules/_steps_sendsrcres_.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/asos-craigmorten/opine-http-proxy/blob/f521001/src/steps/sendSrcRes.ts#L3">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendSrcRes.ts:3</a></li>
+									<li>Defined in <a href="https://github.com/cmorten/opine-http-proxy/blob/f521001/src/steps/sendSrcRes.ts#L3">home/runner/work/opine-http-proxy/opine-http-proxy/src/steps/sendSrcRes.ts:3</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/egg.json
+++ b/egg.json
@@ -1,7 +1,7 @@
 {
     "name": "opine-http-proxy",
     "description": "Proxy middleware for Deno Opine HTTP servers.",
-    "version": "4.0.0",
+    "version": "3.0.1",
     "repository": "https://github.com/cmorten/opine-http-proxy",
     "stable": true,
     "files": [

--- a/egg.json
+++ b/egg.json
@@ -1,8 +1,8 @@
 {
     "name": "opine-http-proxy",
     "description": "Proxy middleware for Deno Opine HTTP servers.",
-    "version": "3.0.0",
-    "repository": "https://github.com/asos-craigmorten/opine-http-proxy",
+    "version": "4.0.0",
+    "repository": "https://github.com/cmorten/opine-http-proxy",
     "stable": true,
     "files": [
         "./mod.ts",
@@ -18,7 +18,7 @@
     "checkInstallation": false,
     "check": false,
     "entry": "./mod.ts",
-    "homepage": "https://github.com/asos-craigmorten/opine-http-proxy",
+    "homepage": "https://github.com/cmorten/opine-http-proxy",
     "ignore": [],
     "unlisted": false
 }

--- a/src/resolveOptions.ts
+++ b/src/resolveOptions.ts
@@ -167,7 +167,7 @@ export interface ProxyOptions
    *
    * @public
    */
-  method?: "string";
+  method?: string;
 }
 
 /**

--- a/test/catchingErrors.test.ts
+++ b/test/catchingErrors.test.ts
@@ -30,7 +30,7 @@ describe("when server responds with an error", () => {
         res.sendStatus(statusCode.code);
       });
       const targetServer = target.listen(0);
-      const targetPort = (targetServer.listener.addr as Deno.NetAddr).port;
+      const targetPort = (targetServer.addrs[0] as Deno.NetAddr).port;
 
       app.use(
         "/proxy",

--- a/test/decorateSrcResHeaders.test.ts
+++ b/test/decorateSrcResHeaders.test.ts
@@ -9,7 +9,7 @@ describe("when userResHeaderDecorator is defined", () => {
       res.json(req.headers);
     });
     const targetServer = target.listen();
-    const targetPort = (targetServer.listener.addr as Deno.NetAddr).port;
+    const targetPort = (targetServer.addrs[0] as Deno.NetAddr).port;
 
     const app = opine();
     app.use(proxy(`http://localhost:${targetPort}`, {

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -1,3 +1,3 @@
-export * from "https://deno.land/x/opine@1.9.1/mod.ts";
+export * from "https://deno.land/x/opine@2.0.2/mod.ts";
 export { expect } from "https://deno.land/x/expect@v0.2.9/mod.ts";
-export { superdeno } from "https://deno.land/x/superdeno@4.7.1/mod.ts";
+export { superdeno } from "https://deno.land/x/superdeno@4.7.2/mod.ts";

--- a/test/filterReq.test.ts
+++ b/test/filterReq.test.ts
@@ -20,7 +20,7 @@ describe("filterReq", () => {
   it("should continue route processing when the filter function returns false (i.e. don't filter)", (done) => {
     const app = opine();
     const proxyServer = proxyTarget({ handlers: proxyRouteFn });
-    const proxyPort = (proxyServer.listener.addr as Deno.NetAddr).port;
+    const proxyPort = (proxyServer.addrs[0] as Deno.NetAddr).port;
 
     app.use(proxy(`localhost:${proxyPort}`, {
       filterReq: () => false,
@@ -40,7 +40,7 @@ describe("filterReq", () => {
   it("should stop route processing when the filter function returns true (i.e. filter)", (done) => {
     const app = opine();
     const proxyServer = proxyTarget({ handlers: proxyRouteFn });
-    const proxyPort = (proxyServer.listener.addr as Deno.NetAddr).port;
+    const proxyPort = (proxyServer.addrs[0] as Deno.NetAddr).port;
 
     app.use(proxy(`localhost:${proxyPort}`, {
       filterReq: () => true,
@@ -60,7 +60,7 @@ describe("filterReq", () => {
   it("should continue route processing when the filter function returns Promise<false> (i.e. don't filter)", (done) => {
     const app = opine();
     const proxyServer = proxyTarget({ handlers: proxyRouteFn });
-    const proxyPort = (proxyServer.listener.addr as Deno.NetAddr).port;
+    const proxyPort = (proxyServer.addrs[0] as Deno.NetAddr).port;
 
     app.use(proxy(`localhost:${proxyPort}`, {
       filterReq: () => Promise.resolve(false),
@@ -80,7 +80,7 @@ describe("filterReq", () => {
   it("should stop route processing when the filter function returns Promise<true> (i.e. filter)", (done) => {
     const app = opine();
     const proxyServer = proxyTarget({ handlers: proxyRouteFn });
-    const proxyPort = (proxyServer.listener.addr as Deno.NetAddr).port;
+    const proxyPort = (proxyServer.addrs[0] as Deno.NetAddr).port;
 
     app.use(proxy(`localhost:${proxyPort}`, {
       filterReq: () => Promise.resolve(true),

--- a/test/handleProxyError.test.ts
+++ b/test/handleProxyError.test.ts
@@ -53,7 +53,7 @@ describe("error handling can be overridden by user", () => {
       it("passes 504 directly to client", (done) => {
         timeoutManager.reset();
         const targetServer = proxyTarget({ handlers: proxyRouteFn });
-        const targetPort = (targetServer.listener.addr as Deno.NetAddr).port;
+        const targetPort = (targetServer.addrs[0] as Deno.NetAddr).port;
 
         const app = opine();
         app.use(proxy(`localhost:${targetPort}`, { timeout: 0 }));
@@ -76,7 +76,7 @@ describe("error handling can be overridden by user", () => {
       it("passes status code (e.g. 504) directly to the client", (done) => {
         timeoutManager.reset();
         const targetServer = proxyTarget({ handlers: proxyRouteFn });
-        const targetPort = (targetServer.listener.addr as Deno.NetAddr).port;
+        const targetPort = (targetServer.addrs[0] as Deno.NetAddr).port;
 
         const app = opine();
         app.use(proxy(`localhost:${targetPort}`));
@@ -95,7 +95,7 @@ describe("error handling can be overridden by user", () => {
       it("passes status code (e.g. 500) back to the client", (done) => {
         timeoutManager.reset();
         const targetServer = proxyTarget({ handlers: proxyRouteFn });
-        const targetPort = (targetServer.listener.addr as Deno.NetAddr).port;
+        const targetPort = (targetServer.addrs[0] as Deno.NetAddr).port;
 
         const app = opine();
         app.use(proxy(`localhost:${targetPort}`));
@@ -122,7 +122,7 @@ describe("error handling can be overridden by user", () => {
       it("should use the provided handler function passing on the timeout error", (done) => {
         timeoutManager.reset();
         const targetServer = proxyTarget({ handlers: proxyRouteFn });
-        const targetPort = (targetServer.listener.addr as Deno.NetAddr).port;
+        const targetPort = (targetServer.addrs[0] as Deno.NetAddr).port;
 
         const app = opine();
         app.use(proxy(`localhost:${targetPort}`, {
@@ -147,7 +147,7 @@ describe("error handling can be overridden by user", () => {
     describe("when the remote server is down", () => {
       it("should use the provided handler function passing on the connection refused error", (done) => {
         const targetServer = proxyTarget({ handlers: proxyRouteFn });
-        const targetPort = (targetServer.listener.addr as Deno.NetAddr).port;
+        const targetPort = (targetServer.addrs[0] as Deno.NetAddr).port;
         targetServer.close();
 
         const app = opine();

--- a/test/payload.test.ts
+++ b/test/payload.test.ts
@@ -21,7 +21,7 @@ describe("when making a proxy request with a payload", () => {
       });
 
       const proxyServer = target.listen();
-      const proxyPort = (proxyServer.listener.addr as Deno.NetAddr).port;
+      const proxyPort = (proxyServer.addrs[0] as Deno.NetAddr).port;
 
       const app = opine();
       app.use("/proxy", proxy(`http://127.0.0.1:${proxyPort}`));
@@ -49,7 +49,7 @@ describe("when making a proxy request with a payload", () => {
       });
 
       const proxyServer = target.listen();
-      const proxyPort = (proxyServer.listener.addr as Deno.NetAddr).port;
+      const proxyPort = (proxyServer.addrs[0] as Deno.NetAddr).port;
 
       const app = opine();
       app.use("/proxy", proxy(`http://127.0.0.1:${proxyPort}`));
@@ -77,7 +77,7 @@ describe("when making a proxy request with a payload", () => {
       });
 
       const proxyServer = target.listen();
-      const proxyPort = (proxyServer.listener.addr as Deno.NetAddr).port;
+      const proxyPort = (proxyServer.addrs[0] as Deno.NetAddr).port;
 
       const app = opine();
       app.use("/proxy", proxy(`http://127.0.0.1:${proxyPort}`));
@@ -105,7 +105,7 @@ describe("when making a proxy request with a payload", () => {
       });
 
       const proxyServer = target.listen();
-      const proxyPort = (proxyServer.listener.addr as Deno.NetAddr).port;
+      const proxyPort = (proxyServer.addrs[0] as Deno.NetAddr).port;
 
       const app = opine();
       app.use(

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -12,7 +12,7 @@ describe("proxies status code", () => {
       });
 
       const targetServer = target.listen();
-      const targetPort = (targetServer.listener.addr as Deno.NetAddr).port;
+      const targetPort = (targetServer.addrs[0] as Deno.NetAddr).port;
 
       const proxyServer = opine();
       proxyServer.use(proxy(`http://localhost:${targetPort}`));

--- a/test/support/utils.ts
+++ b/test/support/utils.ts
@@ -13,7 +13,7 @@ export function describe(_name: string, fn: () => void | Promise<void>) {
   return fn();
 }
 
-export type Done = (err?: Error) => void;
+export type Done = (err?: unknown) => void;
 
 /**
  * An _it_ wrapper around `Deno.test`.
@@ -30,11 +30,16 @@ export function it(
     ...options,
     name,
     fn: async () => {
-      let done: Done = (err?: Error) => {
-        if (err) throw err;
+      let testError: unknown;
+
+      let done: Done = (err?: unknown) => {
+        if (err) {
+          testError = err;
+        }
       };
 
       let race: Promise<unknown> = Promise.resolve();
+      let timeoutId: number;
 
       if (fn.length === 1) {
         let resolve: (value?: unknown) => void;
@@ -42,11 +47,11 @@ export function it(
           resolve = r;
         });
 
-        let timeoutId: number;
-
         race = Promise.race([
           new Promise((_, reject) =>
             timeoutId = setTimeout(() => {
+              clearTimeout(timeoutId);
+
               reject(
                 new Error(
                   `test "${name}" failed to complete by calling "done" within ${TEST_TIMEOUT}ms.`,
@@ -57,15 +62,29 @@ export function it(
           donePromise,
         ]);
 
-        done = (err?: Error) => {
+        done = (err?: unknown) => {
           clearTimeout(timeoutId);
           resolve();
-          if (err) throw err;
+
+          if (err) {
+            testError = err;
+          }
         };
       }
 
       await fn(done);
       await race;
+
+      if (timeoutId!) {
+        clearTimeout(timeoutId);
+      }
+
+      // REF: https://github.com/denoland/deno/blob/987716798fb3bddc9abc7e12c25a043447be5280/ext/timers/01_timers.js#L353
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      if (testError) {
+        throw testError;
+      }
     },
   });
 }

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -26,7 +26,7 @@ describe("url: string", () => {
       };
 
       const target = proxyTarget({ handlers: [proxyRouteFn] });
-      const targetPort = (target.listener.addr as Deno.NetAddr).port;
+      const targetPort = (target.addrs[0] as Deno.NetAddr).port;
 
       const app = opine();
       app.use("/somePath/", proxy(`http://localhost:${targetPort}`));
@@ -58,7 +58,7 @@ describe("url: URL", () => {
       };
 
       const target = proxyTarget({ handlers: [proxyRouteFn] });
-      const targetPort = (target.listener.addr as Deno.NetAddr).port;
+      const targetPort = (target.addrs[0] as Deno.NetAddr).port;
 
       const app = opine();
       app.use("/somePath/", proxy(new URL(`http://localhost:${targetPort}`)));

--- a/test/urlParsing.test.ts
+++ b/test/urlParsing.test.ts
@@ -17,7 +17,7 @@ const proxyRouteFn = [
 describe("url parsing", () => {
   it("can parse a local url with a port", (done) => {
     const target = proxyTarget({ handlers: proxyRouteFn });
-    const targetPort = (target.listener.addr as Deno.NetAddr).port;
+    const targetPort = (target.addrs[0] as Deno.NetAddr).port;
 
     const app = opine();
     app.use(proxy(`http://localhost:${targetPort}`));

--- a/version.ts
+++ b/version.ts
@@ -1,9 +1,9 @@
 /**
  * Version of opine-http-proxy.
  */
-export const VERSION = "3.0.0";
+export const VERSION = "4.0.0";
 
 /**
  * Supported versions of Deno.
  */
-export const DENO_SUPPORTED_VERSIONS = ["1.16.2"];
+export const DENO_SUPPORTED_VERSIONS = ["1.17.2"];

--- a/version.ts
+++ b/version.ts
@@ -1,7 +1,7 @@
 /**
  * Version of opine-http-proxy.
  */
-export const VERSION = "4.0.0";
+export const VERSION = "3.0.1";
 
 /**
  * Supported versions of Deno.


### PR DESCRIPTION
# Issue

Fixes #12 

## Details

- [#12] `method` should have type `string` not `"string"`
- feat: update to Deno `1.17.2`, std `0.120.0`
- feat: upgrade Opine to `2.0.2` in tests
- feat: other minor dependency upgrades
- chore: changes to reflect GitHub repo transfer

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required) before merge to main.
